### PR TITLE
feat: `getResource` with expected type

### DIFF
--- a/src/generator/common.ts
+++ b/src/generator/common.ts
@@ -168,7 +168,7 @@ export const schemaToZod = (
 };
 
 const resourceTypeToUnion = (resourceType: string) => {
-  return `z.union([${resourceReferencesSchemaName(resourceType)}, ${resourceTypeSchemaName(resourceType)}])`;
+  return `z.union([${resourceReferencesSchemaName(resourceType)}, ${resourceTypeSchemaName(resourceType)}.schema])`;
 };
 
 const base64FileZodSchema = once(() => {


### PR DESCRIPTION
Sometimes, you may want to get a resource by dynamic path while ensuring it is
of the type you expect. This PR adds a new overload to `getResource` that allows
you to pass the expected resource type as the second argument, which would check
if the type registered in the generated client for the dynamic path matches.

Example usage:

```ts
import { getResource } from "./client.js";

const connectToPostgres = async (resourcePath: string) => {
  // Will throw if the provided resource is not of a `postgresql` resource
  const postgresResource = await getResource(resourcePath, "postgresql");
  // ...
};
```
