### PR TITLE
feat: `getDefaultResource` helper

### DIFF
--- a/src/generator/resources.ts
+++ b/src/generator/resources.ts
@@ -192,18 +192,20 @@ export const resourceReferencesSchemaName = (resourceType: string) =>
 export const resourceTypeSchemaName = (resourceType: string) =>
   toValidIdentifier(`${resourceType}_type`);
 
-const makeReferencesSchema = (resourceType: string, paths: string[]) => {
+const getResourceTypeDefault = (resourceType: string, paths: string[]) => {
   const { config } = getContext()!;
 
+  return resourceType in config.resources.defaults
+    ? config.resources.defaults[resourceType]
+    : paths.length === 1
+      ? paths[0]
+      : null;
+};
+
+const makeReferencesSchema = (resourceType: string, paths: string[]) => {
   const refs = paths.map((path) => `$res:${path}`);
 
-  let defaultForType =
-    resourceType in config.resources.defaults
-      ? config.resources.defaults[resourceType]
-      : refs.length === 1
-        ? refs[0]
-        : undefined;
-
+  let defaultForType = getResourceTypeDefault(resourceType, refs);
   if (defaultForType != null && !defaultForType.startsWith("$res:")) {
     defaultForType = `$res:${defaultForType}`;
   }

--- a/src/generator/resources.ts
+++ b/src/generator/resources.ts
@@ -73,6 +73,19 @@ const preamble = dedent`
 
     return transformer.call({ arg: parsedData }, parsedData);
   }
+
+  export const getDefaultResource = <
+    T extends keyof typeof defaultPerResourceType,
+  >(
+    resourceType: T,
+  ) => {
+    const path = ${defaultPerResourceTypeMap}[resourceType];
+    if (path == null) {
+      throw new Error(\`No defaults found for resource type \${resourceType}\`);
+    }
+
+    return getResource(path);
+  }
 `;
 
 export const generateResources = async (observer: Observer) => {


### PR DESCRIPTION
This PR introduces a new helper in the generated client: `getDefaultResource`.
Its purpose is to provide you with the "default" resource for a given resource
type. A resource type is considered to have a "default" resource if it only has
one instance or if a default has explicitly been configured in the config.

This matches the behavior of `run{Script,Flow}{,Async}` in the sense that the
same resource inputs that can be omitted may also be retrieved via
`getDefaultResource`.

This is useful in cases where a script may take an optional resource as input
then retrieve a specific resource in case it wasn't provided. This helper would
enable such scripts to request the default resource for the type that they need
as opposed to hardcoding some path.
