### PR TITLE
feat: `listResources` helper

### DIFF
--- a/src/generator/resources.ts
+++ b/src/generator/resources.ts
@@ -88,6 +88,28 @@ const preamble = dedent`
 
     return getResource(path);
   }
+
+  export async function* listResources<Type extends keyof ${resourceTypesTypeName}>(
+    resourceType: Type,
+  ) {
+    for (let page = 1; ; ++page) {
+      const pageData = await wmill.ResourceService.listResource({
+        workspace: process.env["WM_WORKSPACE"]!,
+        page,
+        perPage: 100,
+        resourceType,
+      });
+
+      if (pageData.length === 0) {
+        break;
+      }
+
+      for (const { path } of pageData) {
+        const resource = await getResource(path, resourceType);
+        yield resource;
+      }
+    }
+  }
 `;
 
 export const generateResources = async (observer: Observer) => {


### PR DESCRIPTION
This patch adds a new `listResources` helper to the generated client, which is
an async generator that fetches and yields all resources of a given resource
type.
