### PR TITLE
feat: add resource resolver hook for generated clients

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,4 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm run build
+      - run: pnpm test

--- a/README.md
+++ b/README.md
@@ -187,6 +187,11 @@ export const resolveResource: ResourceResolver = ({ path }) => {
 };
 ```
 
+Configured resolvers are runtime imports used by the generated client in every
+runtime that imports it. Avoid value-import cycles back to the generated client;
+use `import type` for generated-client types, and keep top-level app-only side
+effects out of configured resolver modules.
+
 You can also register or replace a resolver at runtime:
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ resources:
     # Optional extension to append to the import (e.g., ".ts" or ".js")
     importExtension: ".js"
 
+  # Optional resolver hook consulted before the generated client falls back to
+  # embedded resource values or wmill.getResource(path).
+  resolver:
+    # Import path for the resolver, relative to the config
+    importPath: "./resource-resolver"
+    # Name of the exported resolver function
+    importName: "resolveResource"
+    # Optional extension to append to the import (e.g., ".ts" or ".js")
+    importExtension: ".js"
+
 # Script generation configuration
 scripts:
   # Whether to generate script-related code (default: true)
@@ -148,6 +158,55 @@ const flowResult = await runFlow("my/flow/path", {
 const resource = await getResource("my/resource/path");
 // TypeScript will infer the correct type based on the resource type
 ```
+
+### Resource Resolver Hook
+
+Generated clients export a `ResourceResolver` hook API. A resolver can return a
+resource value before the normal generated behavior runs. Returning `undefined`
+continues to the default behavior: embedded value first when configured, then
+`wmill.getResource(path)`. Returned values still go through normal validation
+and resource transformers unless the caller uses `skipValidation` or
+`skipTransformer`.
+
+Configured resolvers are imported from `resources.resolver`:
+
+```typescript
+import type { ResourceResolver } from "./generated-client";
+
+export const resolveResource: ResourceResolver = ({ path }) => {
+  if (path === "f/app/redis" && !process.env["WM_JOB_ID"]) {
+    return {
+      value: {
+        host: process.env["REDIS_HOST"],
+        port: Number(process.env["REDIS_PORT"] ?? 6379),
+      },
+    };
+  }
+
+  return undefined;
+};
+```
+
+You can also register or replace a resolver at runtime:
+
+```typescript
+import { resolvedResource, setResourceResolver } from "./generated-client";
+
+setResourceResolver(({ path }) => {
+  if (path === "f/app/redis") {
+    return resolvedResource({ host: "localhost", port: 6379 });
+  }
+
+  return undefined;
+});
+```
+
+The resolver context includes:
+
+- `path` and `resourceType`
+- `options`, the `getResource` options for the current call
+- `hasEmbeddedResource`
+- `resolveEmbedded()`, `fetchResource()`, and `resolveDefault()` helpers
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -187,10 +187,12 @@ export const resolveResource: ResourceResolver = ({ path }) => {
 };
 ```
 
-Configured resolvers are runtime imports used by the generated client in every
-runtime that imports it. Avoid value-import cycles back to the generated client;
-use `import type` for generated-client types, and keep top-level app-only side
-effects out of configured resolver modules.
+Configured resolver modules are imported by the generated client in every
+environment that imports the client, so their top-level imports and side effects
+run everywhere. Keep top-level imports safe for all target runtimes; if a
+resolver needs a module that is only available in one environment, load it with a
+dynamic `import()` inside that branch. Use `import type` for generated-client
+types to avoid a value-import cycle back into the generated client.
 
 You can also register or replace a resolver at runtime:
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "rimraf dist/ && tsc",
+    "test": "pnpm run build && node --test tests/*.test.mjs",
     "prepublishOnly": "npm run build"
   },
   "keywords": [],

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3,9 +3,9 @@ import { z } from "zod";
 const ImportHookSchema = z
   .object({
     // Import path for the hook, relative to the config
-    importPath: z.string(),
+    importPath: z.string().min(1),
     // Name of the exported hook
-    importName: z.string(),
+    importName: z.string().min(1),
     // Extension to append to the import, if necessary (e.g., '.js' or '.ts')
     importExtension: z.string().default(""),
   })

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
 
-const TransformerSchema = z
+const ImportHookSchema = z
   .object({
-    // Import path for the transformer, relative to the config
+    // Import path for the hook, relative to the config
     importPath: z.string(),
-    // Name of the exported transformer
+    // Name of the exported hook
     importName: z.string(),
     // Extension to append to the import, if necessary (e.g., '.js' or '.ts')
     importExtension: z.string().default(""),
@@ -24,13 +24,15 @@ const ResourceOptionsSchema = z
   .object({
     // Map from resource type to default resource path
     defaults: z.record(z.string(), z.string().nullable()).default({}),
-    transformer: TransformerSchema,
+    transformer: ImportHookSchema,
     individualResourceTypeExports: z.boolean().default(false),
     // When true, resource type schemas will use z.looseObject() instead of z.object()
     // to allow passthrough of unknown fields
     looseSchemas: z.boolean().default(false),
     // Embed resource values directly in the generated client
     embed: EmbedSchema,
+    // Optional resolver hook consulted before embedded/backend resource fetches
+    resolver: ImportHookSchema,
   })
   .prefault({});
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,13 +1,25 @@
 import { z } from "zod";
 
+const ImportNameSchema = z
+  .string()
+  .regex(/^[A-Za-z_$][A-Za-z0-9_$]*$/, "Must be a valid JavaScript identifier");
+
+const ImportExtensionSchema = z
+  .string()
+  .regex(
+    /^(?:|\.[A-Za-z0-9]+)$/,
+    "Must be empty or a dot-prefixed extension",
+  )
+  .default("");
+
 const ImportHookSchema = z
   .object({
     // Import path for the hook, relative to the config
     importPath: z.string().min(1),
     // Name of the exported hook
-    importName: z.string().min(1),
+    importName: ImportNameSchema,
     // Extension to append to the import, if necessary (e.g., '.js' or '.ts')
-    importExtension: z.string().default(""),
+    importExtension: ImportExtensionSchema,
   })
   .nullish();
 

--- a/src/generator/resources.ts
+++ b/src/generator/resources.ts
@@ -14,6 +14,7 @@ const resourceTypesTypeName = "ResourceTypes";
 
 const resourceTransformerName = "_resourcesTransformer";
 const defaultResourceTransformerName = "_DefaultResourceTransformer";
+const configuredResourceResolverName = "_configuredResourceResolver";
 
 const defaultPerResourceTypeMap = "defaultPerResourceType";
 const embeddedResourcesMapName = "_embeddedResources";
@@ -52,12 +53,76 @@ type EmbedPreambleOptions = {
   hasResourcesWithVars: boolean;
 };
 
-const getDataFetchExpr = (embed: EmbedPreambleOptions) => {
-  if (!embed.enabled) return `await wmill.getResource(path)`;
-  const entry = `${embeddedResourcesMapName}[path]`;
-  if (!embed.resolveVariables || !embed.hasResourcesWithVars)
-    return `path in ${embeddedResourcesMapName} ? structuredClone(${entry}.value) : await wmill.getResource(path)`;
-  return `path in ${embeddedResourcesMapName} ? (${entry}.hasVars ? await ${resolveVariablesFnName}(${entry}.value) : structuredClone(${entry}.value)) : await wmill.getResource(path)`;
+type ResourcePreambleOptions = {
+  embed: EmbedPreambleOptions;
+  hasConfiguredResourceResolver: boolean;
+};
+
+type ImportHookConfig = {
+  importPath: string;
+  importName: string;
+  importExtension?: string;
+} | null | undefined;
+
+const resolveConfiguredImport = (
+  hook: ImportHookConfig,
+  outputDir: string,
+  configPath: string | null,
+) => {
+  if (!hook?.importPath || !hook.importName) {
+    return null;
+  }
+
+  const configDir = configPath ? path.dirname(configPath) : process.cwd();
+
+  let importPath = path.resolve(configDir, hook.importPath);
+  importPath = path.relative(outputDir, importPath);
+  if (!importPath.startsWith("./") && !importPath.startsWith("../")) {
+    importPath = `./${importPath}`;
+  }
+
+  const extension = path.extname(importPath);
+  if (extension) {
+    importPath = importPath.slice(0, -extension.length);
+  }
+
+  return {
+    importPath: `${importPath}${hook.importExtension ?? ""}`,
+    importName: hook.importName,
+  };
+};
+
+const getEmbeddedResolverCode = (embed: EmbedPreambleOptions) => {
+  if (!embed.enabled) {
+    return dedent`
+      const _hasEmbeddedResource = (_path: string) => false;
+
+      const _resolveEmbeddedResource = async (
+        _path: string,
+      ): Promise<unknown | undefined> => undefined;
+    `;
+  }
+
+  const valueExpression =
+    embed.resolveVariables && embed.hasResourcesWithVars
+      ? `entry.hasVars ? await ${resolveVariablesFnName}(entry.value) : structuredClone(entry.value)`
+      : "structuredClone(entry.value)";
+
+  return dedent`
+    const _hasEmbeddedResource = (path: string) =>
+      path in ${embeddedResourcesMapName};
+
+    const _resolveEmbeddedResource = async (
+      path: string,
+    ): Promise<unknown | undefined> => {
+      if (!_hasEmbeddedResource(path)) {
+        return undefined;
+      }
+
+      const entry = ${embeddedResourcesMapName}[path as keyof typeof ${embeddedResourcesMapName}];
+      return ${valueExpression};
+    };
+  `;
 };
 
 const hasVarReferences = (obj: unknown): boolean => {
@@ -68,7 +133,10 @@ const hasVarReferences = (obj: unknown): boolean => {
   return false;
 };
 
-const getPreamble = (embed: EmbedPreambleOptions) => dedent`
+const getPreamble = ({
+  embed,
+  hasConfiguredResourceResolver,
+}: ResourcePreambleOptions) => dedent`
   export type Cast<T, U> = T extends U ? T : U;
 
   export interface Transformer {
@@ -84,7 +152,89 @@ const getPreamble = (embed: EmbedPreambleOptions) => dedent`
     ApplyTransformer<typeof ${resourceTransformerName}, Resource>
   >;
 
-  type GetResourceOptions = { skipValidation?: boolean; skipTransformer?: boolean };
+  export type GetResourceOptions = {
+    skipValidation?: boolean;
+    skipTransformer?: boolean;
+  };
+
+  export type ResourcePath = keyof typeof ${resourceToTypeMap};
+  export type ResourceTypeName = keyof ${resourceTypesTypeName} & string;
+
+  export type ResourceResolverContext = {
+    path: string;
+    resourceType: ResourceTypeName;
+    options: Readonly<GetResourceOptions>;
+    hasEmbeddedResource: boolean;
+    resolveEmbedded: () => Promise<unknown | undefined>;
+    fetchResource: () => Promise<unknown>;
+    resolveDefault: () => Promise<unknown>;
+  };
+
+  export type ResourceResolverResult = { value: unknown } | undefined;
+
+  export const resolvedResource = (value: unknown): ResourceResolverResult => ({
+    value,
+  });
+
+  export type ResourceResolver = (
+    context: ResourceResolverContext,
+  ) => ResourceResolverResult | Promise<ResourceResolverResult>;
+
+  let _runtimeResourceResolver: ResourceResolver | undefined;
+
+  export const setResourceResolver = (
+    resolver: ResourceResolver | undefined,
+  ) => {
+    _runtimeResourceResolver = resolver;
+  };
+
+  export const getResourceResolver = (): ResourceResolver | undefined =>
+    _runtimeResourceResolver ?? ${hasConfiguredResourceResolver ? configuredResourceResolverName : "undefined"};
+
+  ${getEmbeddedResolverCode(embed)}
+
+  const _fetchResource = (path: string): Promise<unknown> =>
+    wmill.getResource(path);
+
+  const _resolveDefaultResource = async (path: string): Promise<unknown> => {
+    const embeddedResource = await _resolveEmbeddedResource(path);
+    if (embeddedResource !== undefined) {
+      return embeddedResource;
+    }
+
+    return _fetchResource(path);
+  };
+
+  const _resolveResourceData = async ({
+    path,
+    resourceType,
+    options,
+  }: {
+    path: string;
+    resourceType: ResourceTypeName;
+    options?: GetResourceOptions;
+  }): Promise<unknown> => {
+    const resolver = getResourceResolver();
+    const resolverOptions = Object.freeze({ ...(options ?? {}) });
+
+    const resolveDefault = () => _resolveDefaultResource(path);
+
+    if (resolver == null) {
+      return resolveDefault();
+    }
+
+    const resolved = await resolver({
+      path,
+      resourceType,
+      options: resolverOptions,
+      hasEmbeddedResource: _hasEmbeddedResource(path),
+      resolveEmbedded: () => _resolveEmbeddedResource(path),
+      fetchResource: () => _fetchResource(path),
+      resolveDefault,
+    });
+
+    return resolved === undefined ? resolveDefault() : resolved.value;
+  };
 
   type GetResource = {
     <Path extends keyof typeof ${resourceToTypeMap}>(
@@ -103,23 +253,28 @@ const getPreamble = (embed: EmbedPreambleOptions) => dedent`
     path: string,
     resourceTypeOrOptions?: string | GetResourceOptions,
     maybeOptions?: GetResourceOptions,
-  ) => {
+  ): Promise<any> => {
     const resourceType = typeof resourceTypeOrOptions === "string" ? resourceTypeOrOptions : undefined;
     const options = typeof resourceTypeOrOptions === "object" ? resourceTypeOrOptions : maybeOptions;
 
-    if (${resourceToTypeMap}[path] == null) {
+    const resource = ${resourceToTypeMap}[path as ResourcePath];
+    if (resource == null) {
       throw new Error(\`Unknown resource: \${JSON.stringify(path)}\`);
     }
 
-    const { name, schema } = ${resourceToTypeMap}[path];
+    const { name, schema } = resource;
     if (resourceType != null && name !== resourceType) {
       throw new Error(
         \`Unexpected resource type: expected \${JSON.stringify(resourceType)} but resource \${JSON.stringify(path)} has type \${JSON.stringify(name)}\`,
       );
     }
 
-    const data = ${getDataFetchExpr(embed)};
-    const parsedData = options?.skipValidation ? data : schema.parse(data);
+    const data = await _resolveResourceData({
+      path,
+      resourceType: name as ResourceTypeName,
+      options,
+    });
+    const parsedData = (options?.skipValidation ? data : schema.parse(data)) as object;
 
     if (options?.skipTransformer) {
       return parsedData;
@@ -203,45 +358,34 @@ const getPreamble = (embed: EmbedPreambleOptions) => dedent`
 export const generateResources = async (observer: Observer) => {
   const { write, allResourceTypes, config, outputDir } = getContext()!;
 
-  let transformerPath = config.resources.transformer?.importPath;
-  let transformerName = config.resources.transformer?.importName;
-  const transformerExtension = config.resources.transformer?.importExtension;
-  if (!transformerPath || !transformerName) {
-    transformerName = defaultResourceTransformerName;
-    transformerPath = "";
+  const transformerImport = resolveConfiguredImport(
+    config.resources.transformer,
+    outputDir,
+    config.configPath,
+  );
 
+  if (!transformerImport) {
     await write(defaultResourceTransformer);
   }
 
-  if (transformerPath) {
-    // Resolve path relative to config dir
-    const configDir = config.configPath
-      ? path.dirname(config.configPath)
-      : process.cwd();
-
-    transformerPath = path.resolve(configDir, transformerPath);
-
-    // Get relative path in relation to output dir
-    transformerPath = path.relative(outputDir, transformerPath);
-    if (
-      !transformerPath.startsWith("./") &&
-      !transformerPath.startsWith("../")
-    ) {
-      transformerPath = `./${transformerPath}`;
-    }
-
-    // Strip extension
-    const extension = path.extname(transformerPath);
-    transformerPath = transformerPath.slice(0, -extension.length);
-  }
-
-  if (transformerPath && transformerName) {
+  if (transformerImport) {
     await write(
-      `import { ${transformerName} as ${resourceTransformerName} } from ${JSON.stringify(`${transformerPath}${transformerExtension}`)};`,
+      `import { ${transformerImport.importName} as ${resourceTransformerName} } from ${JSON.stringify(transformerImport.importPath)};`,
     );
   } else {
     await write(
       `const ${resourceTransformerName} = ${defaultResourceTransformerName};`,
+    );
+  }
+
+  const resolverImport = resolveConfiguredImport(
+    config.resources.resolver,
+    outputDir,
+    config.configPath,
+  );
+  if (resolverImport) {
+    await write(
+      `import { ${resolverImport.importName} as ${configuredResourceResolverName} } from ${JSON.stringify(resolverImport.importPath)};`,
     );
   }
 
@@ -305,11 +449,16 @@ export const generateResources = async (observer: Observer) => {
   }
 
   const hasResourcesWithVars = embeddedPathsWithVars.size > 0;
-  await write(getPreamble({
-    enabled: hasEmbeddedResources,
-    resolveVariables: config.resources.embed.resolveVariables,
-    hasResourcesWithVars,
-  }));
+  await write(
+    getPreamble({
+      embed: {
+        enabled: hasEmbeddedResources,
+        resolveVariables: config.resources.embed.resolveVariables,
+        hasResourcesWithVars,
+      },
+      hasConfiguredResourceResolver: resolverImport != null,
+    }),
+  );
 
   observer.next("Generating schemas...");
 
@@ -455,3 +604,9 @@ const makeReferencesSchema = (resourceType: string, paths: string[]) => {
 
 const resourceTypeToTSTypeName = (resourceTypeName: string) =>
   toValidIdentifier(capitalize(camelCase(resourceTypeName)));
+
+export const __testing = {
+  getEmbeddedResolverCode,
+  getPreamble,
+  resolveConfiguredImport,
+};

--- a/src/generator/resources.ts
+++ b/src/generator/resources.ts
@@ -77,17 +77,22 @@ const resolveConfiguredImport = (
 
   let importPath = path.resolve(configDir, hook.importPath);
   importPath = path.relative(outputDir, importPath);
+  importPath = importPath.replace(/\\/g, "/");
   if (!importPath.startsWith("./") && !importPath.startsWith("../")) {
     importPath = `./${importPath}`;
   }
 
-  const extension = path.extname(importPath);
-  if (extension) {
-    importPath = importPath.slice(0, -extension.length);
+  if (hook.importExtension) {
+    const extension = path.extname(importPath);
+    if (extension) {
+      importPath = importPath.slice(0, -extension.length);
+    }
   }
 
   return {
-    importPath: `${importPath}${hook.importExtension ?? ""}`,
+    importPath: hook.importExtension
+      ? `${importPath}${hook.importExtension}`
+      : importPath,
     importName: hook.importName,
   };
 };

--- a/src/windmill/flows.ts
+++ b/src/windmill/flows.ts
@@ -19,14 +19,18 @@ export async function* listFlows(concurrency?: number) {
       break;
     }
 
-    const promises = pageData.map(({ path }) =>
-      queue.add(() =>
+    const promises = pageData.map(async ({ path }) => {
+      const flow = await queue.add(() =>
         wmill.FlowService.getFlowByPath({
           workspace,
           path,
         }),
-      ),
-    );
+      );
+      if (flow == null) {
+        throw new Error(`Flow ${JSON.stringify(path)} returned no data`);
+      }
+      return flow;
+    });
 
     yield* promises;
   }

--- a/src/windmill/scripts.ts
+++ b/src/windmill/scripts.ts
@@ -19,14 +19,18 @@ export async function* listScripts(concurrency?: number) {
       break;
     }
 
-    const promises = pageData.map(({ path }) =>
-      queue.add(() =>
+    const promises = pageData.map(async ({ path }) => {
+      const script = await queue.add(() =>
         wmill.ScriptService.getScriptByPath({
           workspace,
           path,
         }),
-      ),
-    );
+      );
+      if (script == null) {
+        throw new Error(`Script ${JSON.stringify(path)} returned no data`);
+      }
+      return script;
+    });
 
     yield* promises;
   }

--- a/tests/resource-resolver-hook.test.mjs
+++ b/tests/resource-resolver-hook.test.mjs
@@ -1,0 +1,218 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import test from "node:test";
+
+import { ConfigSchema } from "../dist/src/config/schema.js";
+import { __testing } from "../dist/src/generator/resources.js";
+
+test("config schema accepts a resource resolver hook import", () => {
+  const config = ConfigSchema.parse({
+    resources: {
+      resolver: {
+        importPath: "./windmill/resource-resolver",
+        importName: "resolveResource",
+        importExtension: ".js",
+      },
+    },
+  });
+
+  assert.deepEqual(config.resources.resolver, {
+    importPath: "./windmill/resource-resolver",
+    importName: "resolveResource",
+    importExtension: ".js",
+  });
+});
+
+test("configured hook imports are relative to generated output", () => {
+  const resolved = __testing.resolveConfiguredImport(
+    {
+      importPath: "./src/windmill/resource-resolver.ts",
+      importName: "resolveResource",
+      importExtension: ".js",
+    },
+    "/repo/generated",
+    "/repo/windmill-ts.yaml",
+  );
+
+  assert.deepEqual(resolved, {
+    importPath: "../src/windmill/resource-resolver.js",
+    importName: "resolveResource",
+  });
+});
+
+test("configured hook imports work when importPath has no extension", () => {
+  const resolved = __testing.resolveConfiguredImport(
+    {
+      importPath: "./src/windmill/resource-resolver",
+      importName: "resolveResource",
+      importExtension: ".js",
+    },
+    "/repo/generated",
+    "/repo/windmill-ts.yaml",
+  );
+
+  assert.deepEqual(resolved, {
+    importPath: "../src/windmill/resource-resolver.js",
+    importName: "resolveResource",
+  });
+});
+
+test("generated resource preamble exposes and consults the resolver hook", () => {
+  const preamble = __testing.getPreamble({
+    embed: {
+      enabled: false,
+      resolveVariables: true,
+      hasResourcesWithVars: false,
+    },
+    hasConfiguredResourceResolver: false,
+  });
+
+  assert.match(preamble, /export type ResourceResolverContext =/);
+  assert.match(preamble, /export const setResourceResolver =/);
+  assert.match(preamble, /export const getResourceResolver =/);
+  assert.match(preamble, /const resolved = await resolver\(/);
+  assert.match(
+    preamble,
+    /return resolved === undefined \? resolveDefault\(\) : resolved\.value;/,
+  );
+  assert.match(preamble, /_runtimeResourceResolver \?\? undefined/);
+});
+
+test("generated embedded helper keeps variable resolution before fallback", () => {
+  const code = __testing.getEmbeddedResolverCode({
+    enabled: true,
+    resolveVariables: true,
+    hasResourcesWithVars: true,
+  });
+
+  assert.match(code, /path in _embeddedResources/);
+  assert.match(code, /entry\.hasVars \? await _resolveVariables/);
+  assert.match(code, /structuredClone\(entry\.value\)/);
+});
+
+test("generated resolver preamble type-checks in a minimal client", async () => {
+  const tempDir = await mkdtemp(
+    join(process.cwd(), ".tmp-windmill-ts-resolver-test-"),
+  );
+  const sourcePath = join(tempDir, "generated-client.ts");
+
+  const preamble = __testing.getPreamble({
+    embed: {
+      enabled: true,
+      resolveVariables: true,
+      hasResourcesWithVars: true,
+    },
+    hasConfiguredResourceResolver: false,
+  });
+
+  const source = `
+    import { z } from "zod";
+    import * as wmill from "windmill-client";
+
+    const lazyObject = <T extends unknown>(fn: () => T) => {
+      let instance: T | null = null;
+      return new Proxy({}, {
+        get(_target, prop) {
+          if (instance == null) {
+            instance = fn();
+          }
+
+          let value = (instance as any)[prop];
+          if (value instanceof Function) {
+            value = value.bind(instance);
+          }
+
+          return value;
+        }
+      }) as T;
+    };
+
+    class _DefaultResourceTransformer implements Transformer {
+      arg: unknown
+      do(value: Cast<(typeof this)["arg"], object>) {
+        return value;
+      }
+    }
+    const _resourcesTransformer = _DefaultResourceTransformer;
+
+    ${preamble}
+
+    async function _resolveVariables(obj: unknown): Promise<unknown> {
+      if (typeof obj === "string" && obj.startsWith("$var:")) {
+        return wmill.getVariable(obj.substring(5));
+      }
+      if (Array.isArray(obj)) {
+        return Promise.all(obj.map(_resolveVariables));
+      }
+      if (obj != null && typeof obj === "object") {
+        const entries = await Promise.all(
+          Object.entries(obj).map(async ([k, v]) => [k, await _resolveVariables(v)] as const)
+        );
+        return Object.fromEntries(entries);
+      }
+      return obj;
+    }
+
+    const _embeddedResources = {
+      "f/app/redis": {
+        value: { host: "$var:f/app/redis_host", port: 6379 },
+        hasVars: true,
+      },
+    } as const;
+
+    const redis_type = lazyObject(() => ({
+      name: "redis",
+      schema: z.object({ host: z.string(), port: z.number() }),
+    }));
+
+    const resourceToType = lazyObject(() => ({
+      "f/app/redis": redis_type,
+    } as const));
+
+    const pathsPerResourceType = lazyObject(() => ({
+      "redis": ["f/app/redis"] as const,
+    } as const));
+
+    export type ResourceTypes = {
+      "redis": z.infer<(typeof redis_type)["schema"]>,
+    };
+
+    export const defaultPerResourceType = {
+      "redis": "f/app/redis",
+    } as const;
+  `;
+
+  try {
+    await writeFile(sourcePath, source);
+
+    const tscPath = join(process.cwd(), "node_modules/typescript/bin/tsc");
+    const result = spawnSync(
+      process.execPath,
+      [
+        tscPath,
+        "--pretty",
+        "false",
+        "--ignoreConfig",
+        "--noEmit",
+        "--target",
+        "ESNext",
+        "--module",
+        "NodeNext",
+        "--moduleResolution",
+        "NodeNext",
+        "--strict",
+        "--skipLibCheck",
+        "--types",
+        "node",
+        sourcePath,
+      ],
+      { cwd: process.cwd(), encoding: "utf8" },
+    );
+
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});

--- a/tests/resource-resolver-hook.test.mjs
+++ b/tests/resource-resolver-hook.test.mjs
@@ -3,9 +3,182 @@ import { spawnSync } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import test from "node:test";
+import { pathToFileURL } from "node:url";
 
 import { ConfigSchema } from "../dist/src/config/schema.js";
 import { __testing } from "../dist/src/generator/resources.js";
+
+const makeTempDir = () =>
+  mkdtemp(join(process.cwd(), ".tmp-windmill-ts-resolver-test-"));
+
+const runTsc = (args) => {
+  const tscPath = join(process.cwd(), "node_modules/typescript/bin/tsc");
+  return spawnSync(process.execPath, [tscPath, ...args], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+};
+
+const tscArgs = (...args) => [
+  "--pretty",
+  "false",
+  "--ignoreConfig",
+  "--target",
+  "ESNext",
+  "--module",
+  "NodeNext",
+  "--moduleResolution",
+  "NodeNext",
+  "--strict",
+  "--skipLibCheck",
+  "--types",
+  "node",
+  ...args,
+];
+
+const generatedClientSource = ({
+  configuredResolver = false,
+  transformer = "default",
+} = {}) => {
+  const preamble = __testing.getPreamble({
+    embed: {
+      enabled: true,
+      resolveVariables: true,
+      hasResourcesWithVars: true,
+    },
+    hasConfiguredResourceResolver: configuredResolver,
+  });
+
+  const transformerSource =
+    transformer === "mark"
+      ? `
+        class _MarkingResourceTransformer implements Transformer {
+          arg: unknown;
+          do(value: Cast<(typeof this)["arg"], object>) {
+            return { ...value, transformed: true };
+          }
+        }
+        const _resourcesTransformer = _MarkingResourceTransformer;
+      `
+      : `
+        class _DefaultResourceTransformer implements Transformer {
+          arg: unknown
+          do(value: Cast<(typeof this)["arg"], object>) {
+            return value;
+          }
+        }
+        const _resourcesTransformer = _DefaultResourceTransformer;
+      `;
+
+  return `
+    import { z } from "zod";
+    import * as wmill from "windmill-client";
+    ${
+      configuredResolver
+        ? 'import { resolveResource as _configuredResourceResolver } from "./resolver.js";'
+        : ""
+    }
+
+    const lazyObject = <T extends unknown>(fn: () => T) => {
+      let instance: T | null = null;
+      return new Proxy({}, {
+        get(_target, prop) {
+          if (instance == null) {
+            instance = fn();
+          }
+
+          let value = (instance as any)[prop];
+          if (value instanceof Function) {
+            value = value.bind(instance);
+          }
+
+          return value;
+        }
+      }) as T;
+    };
+
+    ${transformerSource}
+
+    ${preamble}
+
+    async function _resolveVariables(obj: unknown): Promise<unknown> {
+      if (typeof obj === "string" && obj.startsWith("$var:")) {
+        return wmill.getVariable(obj.substring(5));
+      }
+      if (Array.isArray(obj)) {
+        return Promise.all(obj.map(_resolveVariables));
+      }
+      if (obj != null && typeof obj === "object") {
+        const entries = await Promise.all(
+          Object.entries(obj).map(async ([k, v]) => [k, await _resolveVariables(v)] as const)
+        );
+        return Object.fromEntries(entries);
+      }
+      return obj;
+    }
+
+    const _embeddedResources = {
+      "f/app/redis": {
+        value: { host: "embedded", port: 6379 },
+        hasVars: false,
+      },
+    } as const;
+
+    const redis_type = lazyObject(() => ({
+      name: "redis",
+      schema: z.object({ host: z.string(), port: z.number() }),
+    }));
+
+    const resourceToType = lazyObject(() => ({
+      "f/app/redis": redis_type,
+    } as const));
+
+    const pathsPerResourceType = lazyObject(() => ({
+      "redis": ["f/app/redis"] as const,
+    } as const));
+
+    export type ResourceTypes = {
+      "redis": z.infer<(typeof redis_type)["schema"]>,
+    };
+
+    export const defaultPerResourceType = {
+      "redis": "f/app/redis",
+    } as const;
+  `;
+};
+
+const writeGeneratedFixture = async (
+  tempDir,
+  options,
+  resolverSource = undefined,
+) => {
+  const sourcePath = join(tempDir, "generated-client.ts");
+  await writeFile(sourcePath, generatedClientSource(options));
+
+  if (resolverSource != null) {
+    await writeFile(join(tempDir, "resolver.ts"), resolverSource);
+  }
+
+  return sourcePath;
+};
+
+const compileGeneratedFixture = async (
+  tempDir,
+  options,
+  resolverSource = undefined,
+) => {
+  const sourcePath = await writeGeneratedFixture(
+    tempDir,
+    options,
+    resolverSource,
+  );
+  const outDir = join(tempDir, "out");
+  const result = runTsc(
+    tscArgs("--outDir", outDir, sourcePath),
+  );
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  return join(outDir, "generated-client.js");
+};
 
 test("config schema accepts a resource resolver hook import", () => {
   const config = ConfigSchema.parse({
@@ -23,6 +196,30 @@ test("config schema accepts a resource resolver hook import", () => {
     importName: "resolveResource",
     importExtension: ".js",
   });
+});
+
+test("config schema rejects empty resource hook import fields", () => {
+  assert.throws(() =>
+    ConfigSchema.parse({
+      resources: {
+        resolver: {
+          importPath: "",
+          importName: "resolveResource",
+        },
+      },
+    }),
+  );
+
+  assert.throws(() =>
+    ConfigSchema.parse({
+      resources: {
+        resolver: {
+          importPath: "./resolver",
+          importName: "",
+        },
+      },
+    }),
+  );
 });
 
 test("configured hook imports are relative to generated output", () => {
@@ -59,6 +256,36 @@ test("configured hook imports work when importPath has no extension", () => {
   });
 });
 
+test("configured hook imports preserve explicit extensions without override", () => {
+  const resolved = __testing.resolveConfiguredImport(
+    {
+      importPath: "./src/windmill/resource-resolver.js",
+      importName: "resolveResource",
+    },
+    "/repo/generated",
+    "/repo/windmill-ts.yaml",
+  );
+
+  assert.deepEqual(resolved, {
+    importPath: "../src/windmill/resource-resolver.js",
+    importName: "resolveResource",
+  });
+});
+
+test("configured hook imports normalize emitted specifiers to POSIX separators", () => {
+  const resolved = __testing.resolveConfiguredImport(
+    {
+      importPath: ".\\resource-resolver.ts",
+      importName: "resolveResource",
+      importExtension: ".js",
+    },
+    "/repo/generated",
+    "/repo/windmill-ts.yaml",
+  );
+
+  assert.equal(resolved?.importPath.includes("\\"), false);
+});
+
 test("generated resource preamble exposes and consults the resolver hook", () => {
   const preamble = __testing.getPreamble({
     embed: {
@@ -93,125 +320,117 @@ test("generated embedded helper keeps variable resolution before fallback", () =
 });
 
 test("generated resolver preamble type-checks in a minimal client", async () => {
-  const tempDir = await mkdtemp(
-    join(process.cwd(), ".tmp-windmill-ts-resolver-test-"),
-  );
-  const sourcePath = join(tempDir, "generated-client.ts");
-
-  const preamble = __testing.getPreamble({
-    embed: {
-      enabled: true,
-      resolveVariables: true,
-      hasResourcesWithVars: true,
-    },
-    hasConfiguredResourceResolver: false,
-  });
-
-  const source = `
-    import { z } from "zod";
-    import * as wmill from "windmill-client";
-
-    const lazyObject = <T extends unknown>(fn: () => T) => {
-      let instance: T | null = null;
-      return new Proxy({}, {
-        get(_target, prop) {
-          if (instance == null) {
-            instance = fn();
-          }
-
-          let value = (instance as any)[prop];
-          if (value instanceof Function) {
-            value = value.bind(instance);
-          }
-
-          return value;
-        }
-      }) as T;
-    };
-
-    class _DefaultResourceTransformer implements Transformer {
-      arg: unknown
-      do(value: Cast<(typeof this)["arg"], object>) {
-        return value;
-      }
-    }
-    const _resourcesTransformer = _DefaultResourceTransformer;
-
-    ${preamble}
-
-    async function _resolveVariables(obj: unknown): Promise<unknown> {
-      if (typeof obj === "string" && obj.startsWith("$var:")) {
-        return wmill.getVariable(obj.substring(5));
-      }
-      if (Array.isArray(obj)) {
-        return Promise.all(obj.map(_resolveVariables));
-      }
-      if (obj != null && typeof obj === "object") {
-        const entries = await Promise.all(
-          Object.entries(obj).map(async ([k, v]) => [k, await _resolveVariables(v)] as const)
-        );
-        return Object.fromEntries(entries);
-      }
-      return obj;
-    }
-
-    const _embeddedResources = {
-      "f/app/redis": {
-        value: { host: "$var:f/app/redis_host", port: 6379 },
-        hasVars: true,
-      },
-    } as const;
-
-    const redis_type = lazyObject(() => ({
-      name: "redis",
-      schema: z.object({ host: z.string(), port: z.number() }),
-    }));
-
-    const resourceToType = lazyObject(() => ({
-      "f/app/redis": redis_type,
-    } as const));
-
-    const pathsPerResourceType = lazyObject(() => ({
-      "redis": ["f/app/redis"] as const,
-    } as const));
-
-    export type ResourceTypes = {
-      "redis": z.infer<(typeof redis_type)["schema"]>,
-    };
-
-    export const defaultPerResourceType = {
-      "redis": "f/app/redis",
-    } as const;
-  `;
+  const tempDir = await makeTempDir();
 
   try {
-    await writeFile(sourcePath, source);
-
-    const tscPath = join(process.cwd(), "node_modules/typescript/bin/tsc");
-    const result = spawnSync(
-      process.execPath,
-      [
-        tscPath,
-        "--pretty",
-        "false",
-        "--ignoreConfig",
-        "--noEmit",
-        "--target",
-        "ESNext",
-        "--module",
-        "NodeNext",
-        "--moduleResolution",
-        "NodeNext",
-        "--strict",
-        "--skipLibCheck",
-        "--types",
-        "node",
-        sourcePath,
-      ],
-      { cwd: process.cwd(), encoding: "utf8" },
-    );
-
+    const sourcePath = await writeGeneratedFixture(tempDir);
+    const result = runTsc(tscArgs("--noEmit", sourcePath));
     assert.equal(result.status, 0, result.stdout + result.stderr);
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test("generated resolver preamble type-checks with configured resolver import", async () => {
+  const tempDir = await makeTempDir();
+
+  try {
+    const sourcePath = await writeGeneratedFixture(
+      tempDir,
+      { configuredResolver: true },
+      `
+        import type { ResourceResolver } from "./generated-client.js";
+
+        export const resolveResource: ResourceResolver = () => ({
+          value: { host: "configured", port: 6379 },
+        });
+      `,
+    );
+    const result = runTsc(tscArgs("--noEmit", sourcePath));
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test("runtime resolver takes precedence and can no-op a configured resolver", async () => {
+  const tempDir = await makeTempDir();
+
+  try {
+    const outputPath = await compileGeneratedFixture(
+      tempDir,
+      { configuredResolver: true },
+      `
+        export const resolveResource = () => ({
+          value: { host: "configured", port: 1 },
+        });
+      `,
+    );
+    const client = await import(pathToFileURL(outputPath).href);
+
+    assert.deepEqual(await client.getResource("f/app/redis"), {
+      host: "configured",
+      port: 1,
+    });
+
+    client.setResourceResolver(() =>
+      client.resolvedResource({ host: "runtime", port: 2 }),
+    );
+    assert.deepEqual(await client.getResource("f/app/redis"), {
+      host: "runtime",
+      port: 2,
+    });
+
+    client.setResourceResolver(() => undefined);
+    assert.deepEqual(await client.getResource("f/app/redis"), {
+      host: "embedded",
+      port: 6379,
+    });
+
+    client.setResourceResolver(undefined);
+    assert.deepEqual(await client.getResource("f/app/redis"), {
+      host: "configured",
+      port: 1,
+    });
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+});
+
+test("resolver output still validates and skipTransformer only skips transformer", async () => {
+  const tempDir = await makeTempDir();
+
+  try {
+    const outputPath = await compileGeneratedFixture(tempDir, {
+      transformer: "mark",
+    });
+    const client = await import(pathToFileURL(outputPath).href);
+
+    let resolverCalls = 0;
+    client.setResourceResolver(() => {
+      resolverCalls++;
+      return client.resolvedResource({ host: "runtime", port: 2 });
+    });
+
+    assert.deepEqual(await client.getResource("f/app/redis"), {
+      host: "runtime",
+      port: 2,
+      transformed: true,
+    });
+
+    assert.deepEqual(
+      await client.getResource("f/app/redis", { skipTransformer: true }),
+      {
+        host: "runtime",
+        port: 2,
+      },
+    );
+    assert.equal(resolverCalls, 2);
+
+    client.setResourceResolver(() =>
+      client.resolvedResource({ host: "invalid", port: "not-a-number" }),
+    );
+    await assert.rejects(() => client.getResource("f/app/redis"));
   } finally {
     await rm(tempDir, { force: true, recursive: true });
   }

--- a/tests/resource-resolver-hook.test.mjs
+++ b/tests/resource-resolver-hook.test.mjs
@@ -198,7 +198,7 @@ test("config schema accepts a resource resolver hook import", () => {
   });
 });
 
-test("config schema rejects empty resource hook import fields", () => {
+test("config schema rejects invalid resource hook import fields", () => {
   assert.throws(() =>
     ConfigSchema.parse({
       resources: {
@@ -220,6 +220,33 @@ test("config schema rejects empty resource hook import fields", () => {
       },
     }),
   );
+
+  for (const importName of ["resolve-resource", " resolveResource", "123resolver"]) {
+    assert.throws(() =>
+      ConfigSchema.parse({
+        resources: {
+          resolver: {
+            importPath: "./resolver",
+            importName,
+          },
+        },
+      }),
+    );
+  }
+
+  for (const importExtension of ["js", ".", ".d.ts", ".js "]) {
+    assert.throws(() =>
+      ConfigSchema.parse({
+        resources: {
+          resolver: {
+            importPath: "./resolver",
+            importName: "resolveResource",
+            importExtension,
+          },
+        },
+      }),
+    );
+  }
 });
 
 test("configured hook imports are relative to generated output", () => {


### PR DESCRIPTION
## Problem

Generated `getResource` currently has one fixed runtime path: use configured embedded values when present, otherwise call `wmill.getResource(path)`, then validate and transform. That makes embedded hot resources fast in Windmill, but shared app/Windmill code has no supported way to override selected resources in app runtime when embedded values contain worker-only hostnames or topology.

## Hook API

This adds a generic resource resolver hook for generated clients:

- config-time resolver import via `resources.resolver.{importPath, importName, importExtension}`
- runtime registration via `setResourceResolver(resolver)`
- exported helper/types: `ResourceResolver`, `ResourceResolverContext`, `ResourceResolverResult`, `resolvedResource(value)`, `getResourceResolver()`
- resolver return contract: return `{ value }` to override, or `undefined` to continue the default embedded-then-backend behavior
- resolver context helpers: `resolveEmbedded()`, `fetchResource()`, and `resolveDefault()`

Resolver results still flow through generated schema validation and resource transformers unless callers pass the existing skip options.

## Backward Compatibility

No config changes are required. Without a configured resolver and without runtime registration, generated clients use the same embedded/backend fallback behavior as before. Existing transformer configuration and embedded variable resolution are preserved.

## Test Coverage

- `pnpm run build`
- `pnpm test`
- config schema parsing for `resources.resolver`
- configured import path resolution
- generated preamble hook dispatch checks
- embedded `$var:` resolution path checks
- strict TypeScript compile check for a minimal generated client using the resolver preamble

## Open Questions

- [ ] Should resolver results eventually get path-specific generic typing instead of `{ value: unknown }`?
- [ ] Should `getDefaultResource` accept `GetResourceOptions` in a follow-up?
- [ ] Should runtime registration support explicitly disabling a configured resolver?
- [ ] Should unknown resource paths ever be hookable, or should generated clients keep the current known-path guard?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable resource resolver hook with runtime APIs to register/replace custom resolvers.

* **Bug Fixes**
  * Stronger validation and explicit errors when flows or scripts are missing.

* **Documentation**
  * README updated with Resource Resolver Hook configuration, behavior, and runtime usage.

* **Tests**
  * New end-to-end test suite validating resolver behavior, precedence, config validation, and runtime APIs.

* **Chores**
  * CI and package test script updated to run the project test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->