### PR TITLE
fix: fall back to any for resource types with no resources

### DIFF
--- a/src/generator/common.ts
+++ b/src/generator/common.ts
@@ -175,7 +175,7 @@ export const schemaToZod = (
         //       doesn't compile. This is also what keeps common argument types
         //       that happen to collide with a resource type name (such as
         //       `Record`, which Windmill added to their hub) working
-        if (!(resourceType in resourceTypes)) {
+        if (!resourceTypes.has(resourceType)) {
           return "z.any()";
         }
 

--- a/src/generator/common.ts
+++ b/src/generator/common.ts
@@ -13,14 +13,18 @@ import type { Observer } from "./index.js";
 import { fixupZodSchema } from "../utils/fixupZodSchema.js";
 
 export const runWithBuffer = async <T,>(cb: () => T) => {
-  const { allResourceTypes, outputDir } = getContext()!;
+  const { outputDir, resourceTypes, workspaceResources } = getContext()!;
 
   const buffer = new PassThrough({
     // The default limit appears to cause writes to start failing when too
     // many resources of a given type exist; this should be high enough
     highWaterMark: 1024 * 1024,
   });
-  const result = await run(buffer, outputDir, allResourceTypes, cb);
+  const result = await run(
+    buffer,
+    { outputDir, resourceTypes, workspaceResources },
+    cb,
+  );
 
   return { buffer, result };
 };
@@ -89,7 +93,7 @@ export const schemaToZod = (
     resourceTypeToSchema = resourceTypeToUnion,
     looseTopLevelObject = false,
   } = options ?? {};
-  const { allResourceTypes } = getContext()!;
+  const { resourceTypes } = getContext()!;
 
   let result = jsonSchemaToZod(schema, {
     parserOverride: (schema, _refs) => {
@@ -164,7 +168,14 @@ export const schemaToZod = (
         //       argument types by parsing the script sources (for TS only),
         //       but handling things like types imported from elsewhere would
         //       not be easy
-        if (!(resourceType in allResourceTypes)) {
+        //
+        //       `resourceTypes` only contains resource types that have at least
+        //       one resource in the workspace, which are the only ones we emit
+        //       schemas for; referring to any other one would produce code that
+        //       doesn't compile. This is also what keeps common argument types
+        //       that happen to collide with a resource type name (such as
+        //       `Record`, which Windmill added to their hub) working
+        if (!(resourceType in resourceTypes)) {
           return "z.any()";
         }
 

--- a/src/generator/context.ts
+++ b/src/generator/context.ts
@@ -2,22 +2,33 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { PassThrough, Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { ResourceTypes } from "../windmill/resourceTypes.js";
+import type { WorkspaceResources } from "../windmill/resources.js";
 import { getConfig, type Config } from "../config/index.js";
 
-type GenerateContext = {
+/**
+ * Everything the generator tasks share, apart from the output stream they
+ * write to.
+ */
+export type SharedContext = {
+  outputDir: string;
+  // NOTE: only contains resource types that have at least one resource in the
+  //       workspace, as those are the only ones we emit schemas for; anything
+  //       else has to fall back to `z.any()` (see `schemaToZod`)
+  resourceTypes: ResourceTypes;
+  workspaceResources: WorkspaceResources;
+};
+
+type GenerateContext = SharedContext & {
   write: (content: string) => Promise<void>;
   deferWrite: (content: string) => void;
-  allResourceTypes: ResourceTypes;
   config: Config;
-  outputDir: string;
 };
 
 const generateStore = new AsyncLocalStorage<GenerateContext>();
 
 export const run = async <T,>(
   output: Writable,
-  outputDir: string,
-  allResourceTypes: ResourceTypes,
+  shared: SharedContext,
   cb: () => T,
 ) => {
   const write = (content: string, stream = output) =>
@@ -46,11 +57,10 @@ export const run = async <T,>(
 
   const result = await generateStore.run(
     {
+      ...shared,
       write,
       deferWrite,
-      allResourceTypes,
       config: await getConfig(),
-      outputDir,
     },
     cb,
   );

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -2,7 +2,11 @@ import { Writable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import { writePreamble } from "./preamble.js";
 import { run } from "./context.js";
-import { listResourceTypes } from "../windmill/resourceTypes.js";
+import {
+  listResourceTypes,
+  type ResourceTypes,
+} from "../windmill/resourceTypes.js";
+import { collectWorkspaceResources } from "../windmill/resources.js";
 import { generateScripts } from "./scripts.js";
 import { generateResources } from "./resources.js";
 import { generateFlows } from "./flows.js";
@@ -46,8 +50,23 @@ export const generate = async (
   const config = await getConfig();
 
   const allResourceTypes = await listResourceTypes();
+  const workspaceResources = await collectWorkspaceResources(allResourceTypes);
 
-  return run(output, outputDir, allResourceTypes, async () => {
+  // NOTE: schemas are only emitted for resource types that have at least one
+  //       resource in the workspace, so those are the only ones the generated
+  //       code can refer to. Narrowing the set here (instead of passing every
+  //       resource type known to the instance) keeps what we generate and what
+  //       we reference in sync, and makes anything else fall back to `z.any()`
+  const resourceTypes: ResourceTypes = Object.fromEntries(
+    [...workspaceResources.resourcesByType.keys()].map((resourceTypeName) => [
+      resourceTypeName,
+      allResourceTypes[resourceTypeName]!,
+    ]),
+  );
+
+  const shared = { outputDir, resourceTypes, workspaceResources };
+
+  return run(output, shared, async () => {
     await writePreamble();
 
     const results = (

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -57,10 +57,10 @@ export const generate = async (
   //       code can refer to. Narrowing the set here (instead of passing every
   //       resource type known to the instance) keeps what we generate and what
   //       we reference in sync, and makes anything else fall back to `z.any()`
-  const resourceTypes: ResourceTypes = Object.fromEntries(
+  const resourceTypes: ResourceTypes = new Map(
     [...workspaceResources.resourcesByType.keys()].map((resourceTypeName) => [
       resourceTypeName,
-      allResourceTypes[resourceTypeName]!,
+      allResourceTypes.get(resourceTypeName)!,
     ]),
   );
 

--- a/src/generator/resources.ts
+++ b/src/generator/resources.ts
@@ -1,5 +1,5 @@
 import toValidIdentifier from "to-valid-identifier";
-import { listResources, getResourceValue } from "../windmill/resources.js";
+import { getResourceValue } from "../windmill/resources.js";
 import type { JSONSchema } from "./types.js";
 import { getContext } from "./context.js";
 import { schemaToZod } from "./common.js";
@@ -361,7 +361,9 @@ const getPreamble = ({
 `;
 
 export const generateResources = async (observer: Observer) => {
-  const { write, allResourceTypes, config, outputDir } = getContext()!;
+  const { write, resourceTypes, workspaceResources, config, outputDir } =
+    getContext()!;
+  const { resourcesByType, pathToResourceType } = workspaceResources;
 
   const transformerImport = resolveConfiguredImport(
     config.resources.transformer,
@@ -394,23 +396,6 @@ export const generateResources = async (observer: Observer) => {
     );
   }
 
-  observer.next("Fetching all resources...");
-  const resourcesByType = new Map<string, string[]>();
-  const allWorkspacePaths = new Map<string, string>();
-  for await (const {
-    resource_type: resourceTypeName,
-    path,
-  } of listResources()) {
-    allWorkspacePaths.set(path, resourceTypeName);
-
-    if (!(resourceTypeName in allResourceTypes)) {
-      continue;
-    }
-
-    const paths = resourcesByType.get(resourceTypeName) ?? [];
-    resourcesByType.set(resourceTypeName, [...paths, path]);
-  }
-
   const hasEmbeddedResources = config.resources.embed.paths.length > 0;
   const embeddedValues = new Map<string, unknown>();
   const embeddedPathsWithVars = new Set<string>();
@@ -424,7 +409,7 @@ export const generateResources = async (observer: Observer) => {
 
     for (const embedPath of config.resources.embed.paths) {
       if (!allKnownPaths.has(embedPath)) {
-        const resourceType = allWorkspacePaths.get(embedPath);
+        const resourceType = pathToResourceType.get(embedPath);
         if (resourceType != null) {
           throw new Error(
             `Embedded resource ${JSON.stringify(embedPath)} has unsupported resource type ${JSON.stringify(resourceType)}`,
@@ -470,7 +455,7 @@ export const generateResources = async (observer: Observer) => {
   const defaultPerResourceType = new Map<string, string>();
 
   for (const [resourceTypeName, paths] of resourcesByType) {
-    const resourceType = allResourceTypes[resourceTypeName]!;
+    const resourceType = resourceTypes[resourceTypeName]!;
 
     const typeSchemaName = resourceTypeSchemaName(resourceType.name);
     const resourceTypeSchema = schemaToZod(resourceType.schema as never, {

--- a/src/generator/resources.ts
+++ b/src/generator/resources.ts
@@ -455,7 +455,7 @@ export const generateResources = async (observer: Observer) => {
   const defaultPerResourceType = new Map<string, string>();
 
   for (const [resourceTypeName, paths] of resourcesByType) {
-    const resourceType = resourceTypes[resourceTypeName]!;
+    const resourceType = resourceTypes.get(resourceTypeName)!;
 
     const typeSchemaName = resourceTypeSchemaName(resourceType.name);
     const resourceTypeSchema = schemaToZod(resourceType.schema as never, {

--- a/src/windmill/resourceTypes.ts
+++ b/src/windmill/resourceTypes.ts
@@ -7,12 +7,12 @@ export const listResourceTypes = async () => {
     workspace,
   });
 
-  return resourceTypes.reduce(
-    (acc, resourceType) => ({
-      ...acc,
-      [resourceType.name]: resourceType,
-    }),
-    {} as Partial<Record<string, wmill.ResourceType>>,
+  // NOTE: a map rather than a plain object, as resource type names are
+  //       arbitrary strings, and ones that collide with `Object.prototype`
+  //       members (`constructor`, `toString`, ...) would otherwise be
+  //       considered present when they aren't
+  return new Map(
+    resourceTypes.map((resourceType) => [resourceType.name, resourceType]),
   );
 };
 

--- a/src/windmill/resources.ts
+++ b/src/windmill/resources.ts
@@ -1,4 +1,5 @@
 import * as wmill from "windmill-client";
+import type { ResourceTypes } from "./resourceTypes.js";
 
 const PER_PAGE = 20;
 
@@ -30,3 +31,36 @@ export async function* listResources(resourceType?: string) {
     yield* pageData;
   }
 }
+
+export type WorkspaceResources = {
+  /**
+   * Paths of all resources in the workspace with a known resource type,
+   * grouped by resource type.
+   */
+  resourcesByType: Map<string, string[]>;
+  /** The resource type of every resource in the workspace, keyed by path. */
+  pathToResourceType: Map<string, string>;
+};
+
+export const collectWorkspaceResources = async (
+  resourceTypes: ResourceTypes,
+): Promise<WorkspaceResources> => {
+  const resourcesByType = new Map<string, string[]>();
+  const pathToResourceType = new Map<string, string>();
+
+  for await (const {
+    resource_type: resourceTypeName,
+    path,
+  } of listResources()) {
+    pathToResourceType.set(path, resourceTypeName);
+
+    if (!(resourceTypeName in resourceTypes)) {
+      continue;
+    }
+
+    const paths = resourcesByType.get(resourceTypeName) ?? [];
+    resourcesByType.set(resourceTypeName, [...paths, path]);
+  }
+
+  return { resourcesByType, pathToResourceType };
+};

--- a/src/windmill/resources.ts
+++ b/src/windmill/resources.ts
@@ -54,12 +54,16 @@ export const collectWorkspaceResources = async (
   } of listResources()) {
     pathToResourceType.set(path, resourceTypeName);
 
-    if (!(resourceTypeName in resourceTypes)) {
+    if (!resourceTypes.has(resourceTypeName)) {
       continue;
     }
 
-    const paths = resourcesByType.get(resourceTypeName) ?? [];
-    resourcesByType.set(resourceTypeName, [...paths, path]);
+    const paths = resourcesByType.get(resourceTypeName);
+    if (paths == null) {
+      resourcesByType.set(resourceTypeName, [path]);
+    } else {
+      paths.push(path);
+    }
   }
 
   return { resourcesByType, pathToResourceType };

--- a/tests/resource-type-fallback.test.mjs
+++ b/tests/resource-type-fallback.test.mjs
@@ -17,7 +17,7 @@ const withResources = (resourcesByType, cb) => {
   const output = new PassThrough();
   output.resume();
 
-  const resourceTypes = Object.fromEntries(
+  const resourceTypes = new Map(
     [...resourcesByType.keys()].map((name) => [
       name,
       { name, schema: { type: "object", properties: {} } },
@@ -43,6 +43,16 @@ test("resource types without any resources fall back to z.any()", async () => {
   assert.match(result, /"arg": z\.any\(\)/);
   assert.equal(result.includes("record_type"), false);
   assert.equal(result.includes("record_references"), false);
+});
+
+test("resource type names colliding with Object.prototype fall back too", async () => {
+  for (const resourceType of ["constructor", "toString"]) {
+    const result = await withResources(new Map(), () =>
+      schemaToZod(argsSchema(resourceType)),
+    );
+
+    assert.match(result, /"arg": z\.any\(\)/);
+  }
 });
 
 test("resource types with resources keep referring to their schemas", async () => {

--- a/tests/resource-type-fallback.test.mjs
+++ b/tests/resource-type-fallback.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { PassThrough } from "node:stream";
+import test from "node:test";
+
+import { schemaToZod } from "../dist/src/generator/common.js";
+import { run } from "../dist/src/generator/context.js";
+
+const argsSchema = (resourceType) => ({
+  type: "object",
+  properties: {
+    arg: { type: "object", format: `resource-${resourceType}` },
+  },
+  required: ["arg"],
+});
+
+const withResources = (resourcesByType, cb) => {
+  const output = new PassThrough();
+  output.resume();
+
+  const resourceTypes = Object.fromEntries(
+    [...resourcesByType.keys()].map((name) => [
+      name,
+      { name, schema: { type: "object", properties: {} } },
+    ]),
+  );
+
+  return run(
+    output,
+    {
+      outputDir: process.cwd(),
+      resourceTypes,
+      workspaceResources: { resourcesByType, pathToResourceType: new Map() },
+    },
+    cb,
+  );
+};
+
+test("resource types without any resources fall back to z.any()", async () => {
+  const result = await withResources(new Map(), () =>
+    schemaToZod(argsSchema("record")),
+  );
+
+  assert.match(result, /"arg": z\.any\(\)/);
+  assert.equal(result.includes("record_type"), false);
+  assert.equal(result.includes("record_references"), false);
+});
+
+test("resource types with resources keep referring to their schemas", async () => {
+  const result = await withResources(
+    new Map([["record", ["f/app/record"]]]),
+    () => schemaToZod(argsSchema("record")),
+  );
+
+  assert.match(result, /record_references/);
+  assert.match(result, /record_type\.schema/);
+});


### PR DESCRIPTION
## Problem

Resource type schemas are only emitted for types that have at least one resource in the workspace, but the guard in `schemaToZod` checked against *every* resource type known to the instance. A script argument typed after a resource type with zero instances therefore generated `z.union([mysql_references, mysql_type.schema])` where neither identifier is ever declared — code that doesn't compile.

This has always been broken (any `Resource<'mysql'>` argument in a workspace without a mysql resource, or any of the types `listResources` excludes: `cache`, `state`, `app_theme`, `app_custom`). It only became noticeable now that Windmill added a `record` resource type to their public hub, which every instance eventually syncs: `Record<K, V>` arguments are parsed as `resource-record`, and what used to fall through the "unknown resource type" branch to `z.any()` now hits the broken path instead.

## Fix

Narrow the resource type set instead of special-casing `record` by name:

- The workspace resource listing moves into `generate()` and runs once up front — the three generator subtasks run concurrently under `Promise.all` and `schemaToZod` is synchronous, so the set has to exist before `run()`. `generateResources` consumes the precomputed maps, so there is no extra fetch.
- The context now carries only the resource types that have at least one resource, i.e. exactly the ones we emit schemas for, so what we generate and what we refer to cannot drift apart.
- `run()` takes a single `SharedContext` object rather than growing to five positional parameters.

Anything else falls back to `z.any()`, like unknown resource types already did.

Known limitation: in a workspace that genuinely has a `record` resource, `Record<K, V>` arguments resolve to the hub `record` schema rather than `any`. That is not distinguishable from a real resource argument without name-based special-casing, and the hub schema is permissive enough to still compile.

## Note

The resource listing now happens before the spinner UI starts, so the CLI is silent during it instead of showing `Generate resources [Fetching all resources...]`. On a large workspace that is a noticeably longer quiet period.

## Testing

`pnpm test` — 14/14 pass, including new coverage asserting that `resource-record` with no instances becomes `z.any()` and that a type with instances still emits `record_references` / `record_type.schema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource schemas are now generated only for resource types present in the current workspace, preventing schema output from including types that aren’t actually available.
  * When a resource type can’t be resolved (including names that could conflict with object keys), generation now reliably falls back to a flexible schema.
* **Tests**
  * Added new test coverage to validate resource-type schema behavior both with no matching workspace resources and with matching resource types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->