### PR TITLE
fix: use the requested workspace name in the missing-workspace error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ program
       const workspace = await getWorkspace(workspaceName);
       if (workspace == null) {
         throw new Error(
-          `Workspace with name ${workspace} not found in Windmill CLI config`,
+          `Workspace with name "${workspaceName}" not found in Windmill CLI config`,
         );
       }
 


### PR DESCRIPTION
One-line fix for the pre-existing remote-mode bug CodeRabbit flagged as **CR-02** on #80.

The missing-workspace error interpolated the null `workspace` variable (guaranteed null inside the `workspace == null` guard), so it printed `Workspace with name null not found in Windmill CLI config`. It now uses the resolved `workspaceName`, consistent with the "defaulting to …" message just above it.

Message-only change on the remote (live-workspace) path — no behavior change. `pnpm test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved missing-workspace error messages by including the specified workspace name for clearer troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->