### PR TITLE
chore: require Node.js 22+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [22, 24]
 
     steps:
       - uses: actions/checkout@v7.0.1

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
   },
   "homepage": "https://github.com/invakid404/windmill-ts#readme",
   "files": ["dist", "README.md"],
+  "engines": {
+    "node": ">=22"
+  },
   "packageManager": "pnpm@10.34.5"
 }


### PR DESCRIPTION
The dependency tree has moved to Node 22, which currently blocks four renovate PRs:

| PR | requires | evidence |
|---|---|---|
| #90 pnpm 11 | `>=22.13` | **CI hard-fails on Node 20**: `ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite` |
| #92 commander 15 | `>=22.12.0` | `engines.node` |
| #91 chalk 6 | `>=22` | `engines.node` |
| #67 log-update 8 | `>=22` (plus `slice-ansi@9`) | `engines.node` |

[Node 20 reached end-of-life in April 2026](https://github.com/nodejs/release#release-schedule), so the matrix was testing an unsupported runtime.

## Changes

- CI matrix `[20, 22]` → `[22, 24]`
- Declare `"engines": { "node": ">=22" }`, so installing on an unsupported runtime fails with a clear message rather than at runtime

## Verification

Build, the full test suite (121/121), and an end-to-end client generation against a real `wmill sync` folder (1126 scripts, 204 flows, 37 resource types) all pass, and the generated client is byte-identical to the pre-change baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015jPtudAKbcSuH2wei54sAx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supported Node.js versions to 22 and newer.
  * Continuous integration now tests against Node.js 22 and 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->